### PR TITLE
[bugfix] pass debug arg in anacont_triqs with BlockGf

### DIFF
--- a/src/adapol/anacont.py
+++ b/src/adapol/anacont.py
@@ -207,7 +207,7 @@ def anacont_triqs(
         func_list, error_list, pol_list, weight_list = [], [], [], []
         for j, (block, delta_blk) in enumerate(Delta_triqs):
             func, fit_error, pol, weight = anacont_triqs(delta_blk, tol, Np, solver, maxiter, mmin,
-                                                         mmax, verbose, statistics=statistics)
+                                                         mmax, verbose, debug=debug, statistics=statistics)
             func_list.append(func)
             if debug:
                 error_list.append(fit_error)


### PR DESCRIPTION
Dear @Hertz4 ,

Here is a bugfix for `anacont_triqs` when running with `debug=True` using a Triqs `BlockGf` the `debug` argument needs to be passed on in the calls for each block of the Green's function.

Please consider merging.

Cheers, Hugo